### PR TITLE
Updating image when switching to game without one.

### DIFF
--- a/custom_components/media_player/ps4.py
+++ b/custom_components/media_player/ps4.py
@@ -224,6 +224,8 @@ class PS4Device(MediaPlayerDevice):
             search_result = json.loads(response.decode('utf-8'))
             if search_result:
                 self._media_image_url = search_result[0]['image-url']
+            if search_result == []:
+                self._media_image_url = MEDIA_IMAGE_DEFAULT
         except urllib.error.URLError as e:
             _LOGGER.debug('Fetching image-url for %s failed %s',
                           titleid, e.reason)


### PR DESCRIPTION
When switching from a game which has an image in online DB to a game which doesn't didn't trigger the image to update to none.


