### PR TITLE
Revert "get images from psn store"

### DIFF
--- a/custom_components/media_player/ps4.py
+++ b/custom_components/media_player/ps4.py
@@ -151,42 +151,12 @@ class PS4Device(MediaPlayerDevice):
         except Exception as e:
             _LOGGER.error("gamesmap json file could not be loaded, %s" % e)
 
-    def psn_cover_art(self):
-        import requests, urllib
-
-        cover_art = None
-        try:
-            url = 'https://store.playstation.com/valkyrie-api/en/US/19/faceted-search/'+urllib.parse.quote(self._media_title.encode('utf-8'))
-            url +='?query='+urllib.parse.quote(self._media_title.encode('utf-8'))+'&platform=ps4'
-            headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Safari/537.36'}
-            r = requests.get(url, headers=headers)
-            for item in r.json()['included']:
-                if 'attributes' in item:
-                    if 'game-content-type' in item['attributes']:
-                        if "App" in item['attributes']['game-content-type'] or "Game" in item['attributes']['game-content-type']:
-                            if 'thumbnail-url-base' in item['attributes']:
-                                cover_art = item['attributes']['thumbnail-url-base']
-                                cover_art += '?w=512&h=512'
-                                break
-        except Exception as e:
-            _LOGGER.error("could not retrieve cover art, %s" % e)
-
-
-        return cover_art
-
-
     @property
     def entity_picture(self):
         if self.state == STATE_OFF:
             return None
 
         if self._local_store is None:
-
-            cover_art = self.psn_cover_art()
-
-            if cover_art != None:
-                return cover_art
-
             image_hash = self.media_image_hash
 
             if image_hash is None:


### PR DESCRIPTION
Reverts hmn/home-assistant-config#17

Looks like it is failing with :

2018-01-05 20:18:59 ERROR (MainThread) [custom_components.media_player.ps4] could not retrieve cover art, 'NoneType' object has no attribute 'encode'
